### PR TITLE
Fix reference to CMS Backend Uri

### DIFF
--- a/classes/Cache.php
+++ b/classes/Cache.php
@@ -143,7 +143,7 @@ class Cache
         return $request->isMethod('GET')
             && $request->getQueryString() == null
             && $response->getStatusCode() == 200
-            && !strpos($request->getUri(), Config::get('cms::backendUri', 'backend'));
+            && !strpos($request->getUri(), Config::get('cms.backendUri', 'backend'));
     }
 
     /**

--- a/classes/middleware/CacheResponse.php
+++ b/classes/middleware/CacheResponse.php
@@ -61,6 +61,6 @@ class CacheResponse
             && $request->getQueryString() == null
             && $response->getStatusCode() == 200
             && BackendAuth::check() == false
-            && !strpos($request->getUri(), Config::get('cms::backendUri', 'backend'));
+            && !strpos($request->getUri(), Config::get('cms.backendUri', 'backend'));
     }
 }


### PR DESCRIPTION
Fixed reference to CMS Backend Uri which was causing back-end to cache if the URL was not /backend.