### PR TITLE
Some fixes and minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This plugin caches every route that opens by GET parameter with 200 response cod
 Open Settings in the control panel of your OctoberCMS website. Go to Updates & Plugins and in search bar type "Quicksilver". Install it by clicking on the icon.
 
 ## Configuration
+### Apache
 
 1. Open `.htaccess` and add the following before `Standard routes` section
 
@@ -41,9 +42,34 @@ Open Settings in the control panel of your OctoberCMS website. Go to Updates & P
 2. Comment out following line in `White listed folders` section.
     ```
     RewriteRule !^index.php index.php [L,NC]
-    ``` 
+    ```
 
 3. **Be sure that plugin can create/write/read "page-cache" folder in your storage path.**
+
+### Nginx
+
+```nginx
+location = / {
+    try_files /storage/page-cache/pc__index__pc.html /index.php?$query_string;
+}
+
+location / {
+    try_files $uri $uri/ /storage/page-cache/$uri.html /storage/page-cache/$uri.json /index.php?$query_string;
+}
+```
+
+If you need to send ajax requests to cached url, you should use this construction
+
+```nginx
+location / {
+    if ($request_method = POST ) {
+        rewrite ^/.*$ /index.php last;
+    }
+
+    try_files $uri $uri/ /storage/page-cache/$uri.html /storage/page-cache/$uri.json /index.php?$query_string;
+}
+```
+
 
 ### Ignoring the cached files
 

--- a/classes/Cache.php
+++ b/classes/Cache.php
@@ -134,9 +134,9 @@ class Cache implements PageCacheContract
     /**
      * @inheritDoc
      */
-    public function clear(): bool
+    public function clear(?string $path = null): bool
     {
-        return $this->files->cleanDirectory($this->getCachePath());
+        return $this->files->cleanDirectory($this->getCachePath($path));
     }
 
     /**
@@ -147,7 +147,7 @@ class Cache implements PageCacheContract
      */
     protected function join(array $paths)
     {
-        $trimmed = array_map(static function (string $path): string {
+        $trimmed = array_map(static function (?string $path): string {
             return trim($path, '/');
         }, $paths);
 

--- a/classes/Cache.php
+++ b/classes/Cache.php
@@ -178,7 +178,8 @@ class Cache implements PageCacheContract
     protected function getDirectoryAndFileNames(Request $request): array
     {
         $requestPath = ltrim($request->getPathInfo(), '/');
-        $segments = explode('/', $requestPath);
+
+        $segments = $requestPath === "" ? [''] : array_filter(explode('/', $requestPath));
 
         $file = $this->aliasFilename(array_pop($segments)).'.html';
         return [

--- a/classes/Cache.php
+++ b/classes/Cache.php
@@ -183,7 +183,7 @@ class Cache implements PageCacheContract
 
         $file = $this->aliasFilename(array_pop($segments)).'.html';
         return [
-            $this->getCachePath($requestPath),
+            $this->getCachePath(implode('/',$segments)),
             $file
         ];
     }

--- a/classes/Cache.php
+++ b/classes/Cache.php
@@ -128,7 +128,7 @@ class Cache implements PageCacheContract
      */
     public function forget(?string $slug): bool
     {
-        return $this->files->delete($this->getCachePath($slug.'.html'));
+        return $this->files->delete($this->getCachePath($this->aliasFilename($slug).'.html'));
     }
 
     /**
@@ -196,7 +196,7 @@ class Cache implements PageCacheContract
      */
     protected function aliasFilename(?string $filename): string
     {
-        return $filename ?: 'pc__index__pc';
+        return in_array($filename,['','/']) ? 'pc__index__pc' : $filename;
     }
 
     /**

--- a/classes/console/ClearCache.php
+++ b/classes/console/ClearCache.php
@@ -11,7 +11,7 @@ class ClearCache extends Command
      *
      * @var string
      */
-    protected $signature = 'page-cache:clear {slug? : URL slug of page to delete}';
+    protected $signature = 'page-cache:clear {slug? : URL slug of page to delete} {--recursive}';
 
     /**
      * The console command description.
@@ -29,7 +29,15 @@ class ClearCache extends Command
     public function handle(Cache $cache): void
     {
         $slug = $this->argument('slug');
-        $this->{$slug ? 'forget' : 'clear'}($cache, $slug);
+        $recursive = $this->option('recursive');
+
+        if (!$slug) {
+            $this->clear($cache);
+        } else if ($recursive) {
+            $this->clear($cache, $slug);
+        } else {
+            $this->forget($cache, $slug);
+        }
     }
 
     /**
@@ -53,15 +61,16 @@ class ClearCache extends Command
      * Clear the full page cache.
      *
      * @param Cache $cache
+     * @param string|null $path
      * @return void
-     * @throws Exception
+     * @throws \BizMark\Quicksilver\Classes\Exceptions\CacheDirectoryPathNotSetException
      */
-    protected function clear(Cache $cache): void
+    protected function clear(Cache $cache, ?string $path = null): void
     {
-        if ($cache->clear()) {
-            $this->info('Page cache cleared at '. $cache->getCachePath());
+        if ($cache->clear($path)) {
+            $this->info('Page cache cleared at '. $cache->getCachePath($path));
         } else {
-            $this->warn('Page cache not cleared at '. $cache->getCachePath());
+            $this->warn('Page cache not cleared at '. $cache->getCachePath($path));
         }
     }
 }

--- a/classes/contracts/Cache.php
+++ b/classes/contracts/Cache.php
@@ -22,6 +22,7 @@ interface Cache
     /**
      * Gets the path to the cache directory.
      *
+     * @param string|null ...$paths
      * @return string
      * @throws CacheDirectoryPathNotSetException
      */
@@ -77,10 +78,11 @@ interface Cache
     /**
      * Fully clear the cache directory.
      *
+     * @param  string|null
      * @return bool
      * @throws Exception
      */
-    public function clear(): bool;
+    public function clear(?string $path): bool;
 
 
 }


### PR DESCRIPTION
Major fix is: Cache - Fix cache location 
- Bug explanation: Plugin stores url cache like here:
         /category-slug/post-slug > /storage/page-cache/category-slug/post-slug/post-slug.html
    But Nginx/Apache loking for the cache here: /storage/page-cache/category-slug/post-slug.html

And minor improvements:
- Cache - Setup ignoring trail slash during path parsing
- Readme - Add nginx config with minor addition
- Cache - Setup clearing cache for root url '/'
- ClearCache - Add to command --recursive option from parent package