### PR TITLE
Querystrings proposal for discussion

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,18 @@ Open Settings in the control panel of your OctoberCMS website. Go to Updates & P
 
 ```nginx
 location = / {
-    try_files /storage/page-cache/pc__index__pc.html /index.php?$query_string;
+    try_files /storage/page-cache/pc__index__pc[q_${args}].html /index.php?$args;
 }
 
 location / {
-    try_files $uri $uri/ /storage/page-cache/$uri.html /storage/page-cache/$uri.json /index.php?$query_string;
+   # Try the Quicksilver cache before booting PHP.
+   try_files $uri $uri/ \
+       /storage/page-cache/${uri}[q_${args}].html \
+       /storage/page-cache/${uri}[q_${args}].json \
+       /storage/page-cache/${uri}[q_${args}].rss \
+       /storage/page-cache/${uri}[q_${args}].xml \
+       /storage/page-cache/${uri}[q_${args}].txt \
+       /index.php?$args;
 }
 ```
 

--- a/classes/Cache.php
+++ b/classes/Cache.php
@@ -112,7 +112,6 @@ class Cache implements PageCacheContract
     public function cache(Request $request, Response $response): PageCacheContract
     {
         [$path, $file] = $this->getDirectoryAndFileNames($request);
-        dd($request);
 
         $this->files->makeDirectory($path, 0775, true, true);
 

--- a/classes/Cache.php
+++ b/classes/Cache.php
@@ -89,8 +89,8 @@ class Cache implements PageCacheContract
      */
     public function shouldCache(Request $request, Response $response): bool
     {
-        $isRequestAccess      = $request->isMethod('GET') && $request->getQueryString() === null;
-        $isRequestQueryAccess = $response->getStatusCode() === 200 && $request->getQueryString() === null;
+        $isRequestAccess      = $request->isMethod('GET');
+        $isRequestQueryAccess = $response->getStatusCode() === 200;
         $isBackendUri         = !Str::contains($request->getUri(), Config::get('cms::backendUri', 'backend'));
         $isNotAssetsCombined  = !Str::contains($request->getUri(), $request->getSchemeAndHttpHost() . '/combine/');
 
@@ -112,6 +112,7 @@ class Cache implements PageCacheContract
     public function cache(Request $request, Response $response): PageCacheContract
     {
         [$path, $file] = $this->getDirectoryAndFileNames($request);
+        dd($request);
 
         $this->files->makeDirectory($path, 0775, true, true);
 

--- a/classes/contracts/Cache.php
+++ b/classes/contracts/Cache.php
@@ -49,14 +49,6 @@ interface Cache
     public function shouldCache(Request $request, Response $response): bool;
 
     /**
-     * Check if file already cached
-     * @param Request $request
-     * @return bool
-     * @throws Exception
-     */
-    public function hasCache(Request $request): bool;
-
-    /**
      * Cache the response to a file.
      *
      * @param Request $request
@@ -67,7 +59,9 @@ interface Cache
     public function cache(Request $request, Response $response): self;
 
     /**
-     * Remove the cached file for the given slug.
+     * Remove the cached files for the given slug.
+     * This will remove all variants and extensions that might exist (query strings, alternative extensions)
+     *
      *
      * @param string|null $slug
      * @return bool

--- a/classes/middleware/CacheResponse.php
+++ b/classes/middleware/CacheResponse.php
@@ -56,8 +56,7 @@ class CacheResponse
     {
         return !$this->isExclude($request)
             && $this->cache->shouldCache($request, $response)
-            && !BackendAuth::check()
-            && !$this->cache->hasCache($request);
+            && !BackendAuth::check();
     }
 
     protected function isExclude(Request $request): bool


### PR DESCRIPTION
Hello,

This is an initial proposal for enabling query string support for all URL's as well as introducing support for json, xml, txt and rss extensions.

This is tested and appears to be working well with Nginx. I do not use Apache so am unsure on how to proceed with modifying the rewrite rules here. Perhaps someone can advise? hopefully it's as simple as Nginx!

**Security considerations**

Per the design of the plugin (and the original Laravel package) all routes which return a 200 code will be cached. This behaviour is unchanged. An attacker could potentially spam URL's with unused params thereby writing many files to disk. 

I would suggest that the end-user of the plugin should be throttling requests with a WAF and returning a 404 if the params sent are invalid, but this is often not the case. Mitigating this attack is probably out of scope for this plugin. The concern should be highlighted, however. Perhaps even make caching for query strings optional via settings.
