### PR TITLE
Class "October\Rain\Support\Date" not found 

### DIFF
--- a/classes/caches/StorageCache.php
+++ b/classes/caches/StorageCache.php
@@ -5,7 +5,7 @@ use Storage, Config, Event;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-use October\Rain\Support\Date;
+use Carbon\Carbon as Date;
 use BizMark\Quicksilver\Models\Settings;
 use BizMark\Quicksilver\Classes\Contracts\Quicksilver;
 


### PR DESCRIPTION
Fix for
Class "October\Rain\Support\Date" not found ~/plugins/bizmark/quicksilver/classes/caches/StorageCache.php line 103
in October v3.